### PR TITLE
Add currency granularity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## [1.3.0](https://github.com/iadvize/javascript-i18n-library/tree/1.3.0) (2016-05-03)
+
+**Implemented features:**
+
+- New currency symbols
+- Currency symbols are contextuals to a locale
+- The formatCurrency function accepts a new parameter to use a currency different of the config one

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ npm install javascript-i18n-library --save
 npm test
 ```
 
+To automatically launch the tests when a file is changed :
+```sh
+npm run-script watch-test
+```
+
 ## Configuration
 
 The factory accept a config object to override default configuration.

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ i18nService.formatNumber(1000.1234, 1); // '1 000,1'
 
 // Format currency
 i18nService.formatCurrency(1000); // '1 000€'
+i18nService.formatCurrency(1000, undefined, '$'), // 1 000$
 i18nService.unformat('1 000€'); // 1000
 
 // Format TimeAgo

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ i18nService.formatNumber(1000.1234, 1); // '1 000,1'
 
 // Format currency
 i18nService.formatCurrency(1000); // '1 000€'
-i18nService.formatCurrency(1000, undefined, '$'), // 1 000$
+i18nService.formatCurrency(1000, '$'), // 1 000$
 i18nService.unformat('1 000€'); // 1000
 
 // Format TimeAgo

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ i18nService.formatNumber(1000.1234, 1); // '1 000,1'
 // Format currency
 i18nService.formatCurrency(1000); // '1 000€'
 i18nService.formatCurrency(1000, '$'), // 1 000$
+i18nService.formatCurrency(1000.1234, 2, '$'), // 1 000,12$
 i18nService.unformat('1 000€'); // 1000
 
 // Format TimeAgo

--- a/javascript-i18n-library.js
+++ b/javascript-i18n-library.js
@@ -198,7 +198,7 @@
         numbro.language(oldLanguage);
         return valueFormated;
       },
-      formatCurrency: function(value, decimalCount) {
+      formatCurrency: function(value, decimalCount, forcedCurrencySymbol) {
         var oldLanguage = numbro.language();
         numbro.language(_config.locale);
         if (decimalCount === undefined) {
@@ -214,7 +214,7 @@
         var dotSymbol = decimalCount === 0 ? '[.]' : '.';
         var valueFormated = numbro(value).formatCurrency('0,0' + dotSymbol + decimalPattern);
         var currentCurrencySymbol = numbro.languages()[_config.locale].currency.symbol;
-        valueFormated = valueFormated.replace(currentCurrencySymbol, _config.currencySymbol);
+        valueFormated = valueFormated.replace(currentCurrencySymbol, forcedCurrencySymbol ? forcedCurrencySymbol : _config.currencySymbol);
         numbro.language(oldLanguage);
         return valueFormated;
       },

--- a/javascript-i18n-library.js
+++ b/javascript-i18n-library.js
@@ -127,7 +127,7 @@
         case 'CHF':
           return 'CHF';
         default:
-          return 'NO CURRENCY';
+          return '¤';
       }
     };
 

--- a/javascript-i18n-library.js
+++ b/javascript-i18n-library.js
@@ -116,19 +116,47 @@
       return timeAgoPayload;
     };
 
-    var _currencyISOToCurrencySymbol = function(currency) {
-      switch(currency) {
-        case 'EUR':
-          return '€';
-        case 'USD':
-          return '$';
-        case 'GBP':
-          return '£';
-        case 'CHF':
-          return 'CHF';
-        default:
-          return '¤';
+    var _currencyISOToCurrencySymbol = function(currency, locale) {
+      var currencies = {
+        "AUD": {"default": "AU$", "fr-FR": "$AU"},
+        "BGN": {"default": "BGN", "it-IT": "Lv"},
+        "BRL": {"default": "BR$"},
+        "CAD": {"default": "CA$", "fr-FR": "$CA"},
+        "CHF": {"default": "CHF"},
+        "CNY": {"default": "CN¥", "fr-FR": "Ұ", "ja-JP": "元", "zh-TW": "￥"},
+        "CZK": {"default": "CZK"},
+        "DKK": {"default": "DKK", "fr-FR": "krD"},
+        "EUR": {"default": "€"},
+        "GBP": {"default": "£", "fr-FR": "£UK"},
+        "HKD": {"default": "HK$", "fr-FR": "$HK"},
+        "HRK": {"default": "HRK"},
+        "HUF": {"default": "HUF"},
+        "IDR": {"default": "IDR"},
+        "ILS": {"default": "₪"},
+        "INR": {"default": "₹"},
+        "JPY": {"default": "JP¥", "fr-FR": "¥JP", "en-GB": "¥", "de-DE": "¥", "ja-JP": "￥"},
+        "KRW": {"default": "₩", "ja-JP": "￦", "zh-TW": "￦"},
+        "MXN": {"default": "MX$"},
+        "MYR": {"default": "MYR"},
+        "NOK": {"default": "NOK", "fr-FR": "krN", "sv-SE": "NKr"},
+        "NZD": {"default": "NZ$", "fr-FR": "$NZ"},
+        "PHP": {"default": "PHP"},
+        "PLN": {"default": "PLN"},
+        "RON": {"default": "RON", "it-IT": "L"},
+        "RUB": {"default": "RUB"},
+        "SEK": {"default": "SEK", "fr-FR": "krS", "sv-SE": "kr"},
+        "SGD": {"default": "SGD", "fr-FR": "$SG"},
+        "THB": {"default": "฿"},
+        "TRY": {"default": "TRY"},
+        "USD": {"default": "US$", "en-US": "$", "fr-FR": "$US", "en-GB": "$", "de-DE": "$", "ja-JP": "$", "zh-TW": "$"},
+        "ZAR": {"default": "ZAR"}
+      };
+
+      if (currencies[currency]) {
+        return currencies[currency][locale] || currencies[currency]['default'];
       }
+
+      return '¤';
     };
 
     if (!!config) {
@@ -136,7 +164,7 @@
     }
 
     _config.timeFormat = _config.isMeridianTime ? 'meridian' : 'h24';
-    _config.currencySymbol = _currencyISOToCurrencySymbol(_config.currency);
+    _config.currencySymbol = _currencyISOToCurrencySymbol(_config.currency, _config.locale);
 
     return {
       getTimeAgoFromTimestamp: function(timestamp) {
@@ -198,9 +226,15 @@
         numbro.language(oldLanguage);
         return valueFormated;
       },
-      formatCurrency: function(value, decimalCount, forcedCurrencySymbol) {
+      formatCurrency: function(value, decimalCount, forcedCurrency) {
         var oldLanguage = numbro.language();
         numbro.language(_config.locale);
+
+        if (typeof decimalCount === 'string') {
+          forcedCurrency = decimalCount;
+          decimalCount = undefined;
+        }
+
         if (decimalCount === undefined) {
           var splittedValue = value.toString().split('.');
           if(!!splittedValue[1]) {
@@ -214,7 +248,8 @@
         var dotSymbol = decimalCount === 0 ? '[.]' : '.';
         var valueFormated = numbro(value).formatCurrency('0,0' + dotSymbol + decimalPattern);
         var currentCurrencySymbol = numbro.languages()[_config.locale].currency.symbol;
-        valueFormated = valueFormated.replace(currentCurrencySymbol, forcedCurrencySymbol ? forcedCurrencySymbol : _config.currencySymbol);
+        var currencySymbol = forcedCurrency ? _currencyISOToCurrencySymbol(forcedCurrency, _config.locale) : _config.currencySymbol;
+        valueFormated = valueFormated.replace(currentCurrencySymbol, currencySymbol);
         numbro.language(oldLanguage);
         return valueFormated;
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "javascript-i18n-library",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "This javascript library is used to format dates, numbers and currencies. It's compatible with Node and Browsers.",
   "main": "javascript-i18n-library.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "test": "npm run test-node",
-    "test-node": "./node_modules/mocha/bin/mocha -R spec ./test/node/index.js"
+    "test-node": "./node_modules/mocha/bin/mocha -R spec ./test/node/index.js",
+    "watch-test": "./node_modules/mocha/bin/mocha -w -R spec ./test/node/index.js"
   }
 }

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -513,3 +513,39 @@ describe('Currency format and unformat', function() {
     });
   });
 });
+
+describe('Currency format with forced currency', function() {
+  var forcedCurrencySymbol = 'US$';
+  var scenarios =
+    [
+      {
+        locale: 'fr-FR',
+        value: 1000,
+        currency: 'EUR',
+        expected: '1 000' + forcedCurrencySymbol
+      },
+      {
+        locale: 'fr-FR',
+        value: 1000.1234,
+        currency: 'USD',
+        expected: '1 000,1234' + forcedCurrencySymbol
+      },
+      {
+        locale: 'en-GB',
+        value: 1000,
+        currency: 'CHF',
+        expected: forcedCurrencySymbol + '1,000'
+      }
+    ];
+
+  scenarios.forEach(function(scenario) {
+    it('should format with the forced currency ' + forcedCurrencySymbol, function() {
+      var i18nService = i18nServiceFactory({
+        locale: scenario.locale,
+        currency: scenario.currency
+      });
+      var result = i18nService.formatCurrency(scenario.value, scenario['decimalCount'], forcedCurrencySymbol);
+      assert.equal(scenario.expected, result);
+    });
+  });
+});

--- a/test/node/index.js
+++ b/test/node/index.js
@@ -478,7 +478,7 @@ describe('Currency format and unformat', function() {
         locale: 'fr-FR',
         value: 1000.1234,
         currency: 'USD',
-        expected: '1 000,1234$'
+        expected: '1 000,1234$US'
       },
       {
         locale: 'en-GB',
@@ -515,36 +515,95 @@ describe('Currency format and unformat', function() {
 });
 
 describe('Currency format with forced currency', function() {
-  var forcedCurrencySymbol = 'US$';
   var scenarios =
     [
       {
         locale: 'fr-FR',
         value: 1000,
         currency: 'EUR',
-        expected: '1 000' + forcedCurrencySymbol
+        forcedCurrency: 'USD',
+        expected: '1 000$US'
       },
       {
         locale: 'fr-FR',
         value: 1000.1234,
         currency: 'USD',
-        expected: '1 000,1234' + forcedCurrencySymbol
+        forcedCurrency: 'USD',
+        expected: '1 000,1234$US'
       },
       {
         locale: 'en-GB',
         value: 1000,
         currency: 'CHF',
-        expected: forcedCurrencySymbol + '1,000'
+        forcedCurrency: 'USD',
+        expected: '$1,000'
+      },
+      {
+        locale: 'en-GB',
+        value: 1000,
+        currency: 'CHF',
+        forcedCurrency: 'UNKNOWN',
+        expected: '¤1,000'
       }
+
     ];
 
   scenarios.forEach(function(scenario) {
-    it('should format with the forced currency ' + forcedCurrencySymbol, function() {
+    it('should format ' + scenario.locale + ' with currency ' + scenario.forcedCurrency, function() {
       var i18nService = i18nServiceFactory({
         locale: scenario.locale,
         currency: scenario.currency
       });
-      var result = i18nService.formatCurrency(scenario.value, scenario['decimalCount'], forcedCurrencySymbol);
+      var result = i18nService.formatCurrency(scenario.value, scenario.forcedCurrency);
+      assert.equal(scenario.expected, result);
+    });
+  });
+});
+
+describe('Currency format with forced currency and decimal count', function() {
+  var scenarios =
+    [
+      {
+        locale: 'fr-FR',
+        value: 1000,
+        currency: 'EUR',
+        forcedCurrency: 'USD',
+        expected: '1 000$US',
+        decimalCount: undefined
+      },
+      {
+        locale: 'fr-FR',
+        value: 1000.1234,
+        currency: 'USD',
+        forcedCurrency: 'USD',
+        expected: '1 000,12$US',
+        decimalCount: 2
+      },
+      {
+        locale: 'fr-FR',
+        value: 1000.1234,
+        currency: 'USD',
+        forcedCurrency: 'USD',
+        expected: '1 000$US',
+        decimalCount: 0
+      },
+      {
+        locale: 'en-GB',
+        value: 1000,
+        currency: 'CHF',
+        forcedCurrency: 'USD',
+        expected: '$1,000',
+        decimalCount: null
+      }
+    ];
+
+  scenarios.forEach(function(scenario) {
+    it('should format ' + scenario.locale + ' with currency ' + scenario.forcedCurrency + ' and ' + scenario.decimalCount + ' decimals', function() {
+      var i18nService = i18nServiceFactory({
+        locale: scenario.locale,
+        currency: scenario.currency
+      });
+      var result = i18nService.formatCurrency(scenario.value, scenario.decimalCount, scenario.forcedCurrency);
       assert.equal(scenario.expected, result);
     });
   });


### PR DESCRIPTION
The first modification is to change the 'NO CURRENCY' in the symbol for generic currency '¤' which has the advantage to be more consistent with the other symbols.

The second modification aims to let the formatCurrency have a custom currency symbol.
Two objectives :
* You can use some amounts in different currencies on a single page - a single central currency configuration is not enough to do that
* There are not a lot of 'code to symbol' currency relationships in the file and those symbols are not local dependent (ie. the US dollar should be '$' with a en-US local but 'US$' with a en-CA local). The Number.prototype.toLocaleString function could be an answer but the browser compatibility is not perfect (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString#Browser_Compatibility).
